### PR TITLE
Comply with RFC 3986

### DIFF
--- a/src/routing_tree_leex.xrl
+++ b/src/routing_tree_leex.xrl
@@ -1,14 +1,12 @@
 Definitions.
-PathSegment = (_|[a-zA-Z]|[0-9])*
+PathSegment = (_|-|\.|~|:|/|\[|\]|@|!|\$|\'|\(|\)|\*|\+|,|;|\%|[a-zA-Z]|[0-9])*
 Divider = (\/)
 
 Rules.
 
 {Divider}+      : {token, {'divider', TokenLine}}.
-\:{PathSegment} : {token, {'binding', TokenLine, strip(TokenChars)}}.
 \[\.\.\.\]      : {token, {'wildcard', TokenLine, '...'}}.
-\[              : {token, {'optional_left', TokenLine}}.
-\]              : {token, {'optional_right', TokenLine}}.
+\:{PathSegment} : {token, {'binding', TokenLine, strip(TokenChars)}}.
 \?              : {token, {'query_start', TokenLine}}.
 \&              : {token, {'ampersand', TokenLine}}.
 \=              : {token, {'equals', TokenLine}}.

--- a/src/routing_tree_parser.yrl
+++ b/src/routing_tree_parser.yrl
@@ -1,6 +1,6 @@
-Nonterminals url_path path_segment query optional_segment basic_element.
+Nonterminals url_path path_segment query basic_element.
 
-Terminals 'divider' 'binding' 'wildcard' 'optional_left' 'optional_right' 'segment' 'query_start' 'ampersand' 'equals'.
+Terminals 'divider' 'binding' 'wildcard' 'segment' 'query_start' 'ampersand' 'equals'.
 
 Rootsymbol url_path.
 
@@ -9,14 +9,6 @@ basic_element ->
     'binding': '$1'.
 basic_element ->
     'segment': '$1'.
-
-%% Optional segments can only be at the end of this
-optional_segment ->
-    'divider' 'optional_left' basic_element 'optional_right': [optional('$3')].
-optional_segment ->
-    'divider' 'optional_left' basic_element 'optional_right' query: [optional('$3')|'$5'].
-optional_segment ->
-    'divider' 'optional_left' basic_element 'optional_right' optional_segment: [optional('$3')|'$5'].
 
 query ->
     'segment' 'equals' 'segment': [{'query', '$1', '$3'}].
@@ -30,8 +22,6 @@ path_segment ->
 path_segment ->
     'divider' 'wildcard': ['$2'].
 path_segment ->
-    optional_segment: '$1'.
-path_segment ->
     'divider' basic_element: ['$2'].
 path_segment ->
     'divider' basic_element path_segment: ['$2'|'$3'].
@@ -44,6 +34,3 @@ url_path ->
 
 
 Erlang code.
-
-optional(X) ->
-    {optional, X}.


### PR DESCRIPTION
This extends the valid characters of a URL in accordance to RFC 3986 (https://www.ietf.org/rfc/rfc3986.txt). It also removes the unsupported optional segments in a URI.

Optional segments were previously expressed within brackets (Eg `/my/optional/[path]`) which would be extended to the two cases:

`/my/optional` and `/my/optional/path`. 

We decided that supporting this syntax would cause more headache both in implementation but also for the end-users. It's a lot clearer to have to separate paths described rather than one with optional parameters.
